### PR TITLE
REPL window should not close before server returns

### DIFF
--- a/app/assets/javascripts/angular/controllers/alerts/alert_show_controller.js.es6
+++ b/app/assets/javascripts/angular/controllers/alerts/alert_show_controller.js.es6
@@ -19,8 +19,8 @@
       if ($routeParams.alertId === 'new') {
         this.alert.initItem()
           .then(this.query.initItem.bind(this.query, null))
-          .then(this._openReplService.open.bind(this._openReplService, {}))
-          .then(({query, _}) => {
+          .then(this._openReplService.open.bind(this._openReplService, { skipSave: true }))
+          .then(query => {
             this.query = query;
             this.alert.item.query_title = query.item.title;
             this.query.item.tags.push('alert-query');
@@ -59,9 +59,9 @@
     editAlert() {
       this._openReplService.open({
         query: this.query
-      }).then(({query, result}) => {
+      }).then(query => {
         this.query = query;
-        return this.query.save({result_id: result.id});
+        return this.query.save();
       }).then(this.alert.save.bind(this.alert));
     }
 

--- a/app/assets/javascripts/angular/controllers/query/query_index_controller.js.es6
+++ b/app/assets/javascripts/angular/controllers/query/query_index_controller.js.es6
@@ -24,7 +24,7 @@
         this._roleModel = RoleModel;
         this._tagResource = TagResource;
         this._$q = $q;
-        this._openReplService = OpenReplService;
+        this._repl = OpenReplService;
 
         RoleModel.initCollection();
     }
@@ -61,10 +61,7 @@
     }
 
     openRepl() {
-      this._openReplService.open()
-        .then(({query, result}) => {
-          return query.save({ result_id: result.id });
-        })
+      this._repl.open()
         .then(this._handler.navigateToLatestVersion.bind(this._handler))
         .then(this._handler.success.bind(this._handler, 'create', true))
         .catch(this._handler.handleReplExit.bind(this._handler));

--- a/app/assets/javascripts/angular/controllers/query/query_repl_controller.js.es6
+++ b/app/assets/javascripts/angular/controllers/query/query_repl_controller.js.es6
@@ -2,12 +2,11 @@
   'use strict';
 
   class QueryReplController {
-    constructor($uibModalInstance, getResultCsv, DefaultAceConfigurator, ResultRunner, query,
-      Results, NavigationGuard, KeyBindings, hotkeys, $scope) {
+    constructor($uibModalInstance, getResultCsv, DefaultAceConfigurator, ResultRunner, Query,
+      Results, NavigationGuard, KeyBindings, hotkeys, options, $scope) {
+        this._initQuery(options, Query);
         this._modalInstance = $uibModalInstance;
-
         this.results = new Results();
-        this.query = query;
         this.resultRunner = new ResultRunner(this.query, this.results, {
           sandbox: true,
           enablePolling: true
@@ -78,11 +77,25 @@
       this._navigationGuard.disable();
       this._setParameterDefaultValues(this.query.item.version.parameters, this.resultRunner.substitutionValues);
       let result = this.results.collection.shift();
+      if(this._options.skipSave) {
+        /* FIXME: this is for alerts where we want to pop up the repl and save later
+           We probably have to rethink the alerts UI/UX to take this hack out */
+        let copy = new this._Query();
+        copy.internalize(this.query.item);
+        this._modalInstance.close(copy);
+      } else {
+        this.query.save(_.exists(result) ? { result_id: result.item.id } : {})
+          .then(item => {
+            let model = new this._Query();
+            model.internalize(item);
+            this._modalInstance.close(model);
+          })
+          .catch(err => {
+            console.error('query save failed', err);
+            alert('Query save failed!');
+          });
+      }
 
-      this._modalInstance.close({
-        query: this.query,
-        result: _.exists(result) ? result.item : {},
-      });
     }
 
     exit() {
@@ -112,6 +125,17 @@
       });
     }
 
+    _initQuery(options, Query) {
+      this._Query = Query;
+      this._options = options;
+      this.query = new Query();
+      if(_.exists(options.query)) {
+        this.query.internalize(angular.copy(options.query.item));
+      } else {
+        this.query.initItem();
+      }
+    }
+
     _initKeyBindings(KeyBindings, hotkeys, $scope) {
       this._saveKb = KeyBindings.saveQuery.withKeyFn(() => {
         if(this.validToSave()) {
@@ -138,7 +162,7 @@
   }
 
   QueryReplController.$inject = ['$uibModalInstance', 'getResultCsv', 'DefaultAceConfigurator', 'ResultRunner',
-    'query', 'Results', 'NavigationGuard', 'KeyBindings', 'hotkeys', '$scope'];
+    'Query', 'Results', 'NavigationGuard', 'KeyBindings', 'hotkeys', 'options', '$scope'];
 
   angular
     .module('alephControllers.queryReplController', ['alephServices'])

--- a/app/assets/javascripts/angular/controllers/query/query_repl_controller.js.es6
+++ b/app/assets/javascripts/angular/controllers/query/query_repl_controller.js.es6
@@ -80,16 +80,10 @@
       if(this._options.skipSave) {
         /* FIXME: this is for alerts where we want to pop up the repl and save later
            We probably have to rethink the alerts UI/UX to take this hack out */
-        let copy = new this._Query();
-        copy.internalize(this.query.item);
-        this._modalInstance.close(copy);
+        this._toModelAndClose(angular.copy(this.query.item));
       } else {
         this.query.save(_.exists(result) ? { result_id: result.item.id } : {})
-          .then(item => {
-            let model = new this._Query();
-            model.internalize(item);
-            this._modalInstance.close(model);
-          })
+          .then(this._toModelAndClose.bind(this))
           .catch(err => {
             console.error('query save failed', err);
             alert('Query save failed!');
@@ -111,6 +105,12 @@
     }
 
     // private methods
+
+    _toModelAndClose(item) {
+      let model = new this._Query();
+      model.internalize(item);
+      this._modalInstance.close(model);
+    }
 
     _queryBody() {
       return this.query.item.version.body;

--- a/app/assets/javascripts/angular/directives/query/query_details_directive.js.es6
+++ b/app/assets/javascripts/angular/directives/query/query_details_directive.js.es6
@@ -18,7 +18,6 @@
 
     openRepl() {
       this._repl.open( { query: this.query } )
-        .then(({query, result}) => query.save({ result_id: result.id }))
         .then(this._handler.navigateToLatestVersion.bind(this._handler))
         .then(this._handler.success.bind(this._handler, 'update', false))
         .catch(this._handler.handleReplExit.bind(this._handler))

--- a/app/assets/javascripts/angular/services/lib/open_repl_service.js.es6
+++ b/app/assets/javascripts/angular/services/lib/open_repl_service.js.es6
@@ -3,9 +3,8 @@
 
   class OpenReplService {
 
-    constructor($uibModal, Query, AceCompleters) {
+    constructor($uibModal, AceCompleters) {
       this._$modal = $uibModal;
-      this._Query = Query;
       this._AceCompleters = AceCompleters;
     }
 
@@ -28,7 +27,7 @@
     }
   }
 
-  OpenReplService.$inject = ['$uibModal', 'Query', 'AceCompleters'];
+  OpenReplService.$inject = ['$uibModal', 'AceCompleters'];
   angular.module('alephServices.openReplService', []).service('OpenReplService', OpenReplService);
 
 }(angular));

--- a/app/assets/javascripts/angular/services/lib/open_repl_service.js.es6
+++ b/app/assets/javascripts/angular/services/lib/open_repl_service.js.es6
@@ -21,32 +21,10 @@
         windowClass: 'query-repl-dialog',
         backdrop: 'static',
         keyboard: false,
-        resolve: {
-          query: () =>  _.exists(options.query) ? this._clone(options.query) : this._newQuery()
-        }
+        resolve: { options: () =>  options }
       });
 
-      return modalInstance.result.then(({query, result}) => {
-        return {
-          query: this._clone(query),
-          result: result
-        };
-      });
-    }
-
-    // private methods
-
-    _clone(q) {
-      let copiedItem = angular.copy(q.item);
-      let m = new this._Query();
-      m.internalize(copiedItem);
-      return m;
-    }
-
-    _newQuery() {
-      let m = new this._Query();
-      m.initItem();
-      return m;
+      return modalInstance.result;
     }
   }
 

--- a/app/assets/javascripts/angular/services/query/query_handler.js.es6
+++ b/app/assets/javascripts/angular/services/query/query_handler.js.es6
@@ -12,7 +12,7 @@
       let _action =  action || 'action';
       let _schedule = _.exists(schedule) ? schedule : false;
 
-      this._alertFlash.emitSuccess('Query "' + query.title + '" ' + _action + 'd!', _schedule);
+      this._alertFlash.emitSuccess('Query "' + query.item.title + '" ' + _action + 'd!', _schedule);
       return query;
     }
 
@@ -26,7 +26,7 @@
     }
 
     navigateToLatestVersion(query) {
-      this._$location.path('/queries/' + query.id + '/query_versions/' + query.version.id);
+      this._$location.path('/queries/' + query.item.id + '/query_versions/' + query.item.version.id);
       return query;
     }
 

--- a/spec/javascripts/angular_controllers/alert/alert_show_controller_spec.js.es6
+++ b/spec/javascripts/angular_controllers/alert/alert_show_controller_spec.js.es6
@@ -11,7 +11,6 @@ describe('Alert Show Controller', () => {
   let DefaultAceConfigurator;
   let defaultAceConfigurator;
   let OpenReplService;
-  let replSuccess;
   let replQuery;
   let $routeParams;
   let $controller;
@@ -64,12 +63,8 @@ describe('Alert Show Controller', () => {
       },
       save: jasmine.createSpy('replQuery.save').and.returnValue({})
     };
-    replSuccess = {
-      query: replQuery,
-      result: { id: 11 }
-    };
     OpenReplService = {
-      open: jasmine.createSpy('OpenReplService.open').and.returnValue($q.when(replSuccess))
+      open: jasmine.createSpy('OpenReplService.open').and.returnValue($q.when(replQuery))
     };
 
     $scope = {};
@@ -112,8 +107,8 @@ describe('Alert Show Controller', () => {
           expect(query.initItem).toHaveBeenCalled();
         });
 
-        it('calls OpenReplService.open', () => {
-          expect(OpenReplService.open).toHaveBeenCalled();
+        it('calls OpenReplService.open with skipSave == true', () => {
+          expect(OpenReplService.open.calls.argsFor(0)[0]).toEqual({ skipSave: true });
         });
 
         it('sets alert.item.query_title from the repl query.item.title', () => {
@@ -230,11 +225,11 @@ describe('Alert Show Controller', () => {
       });
 
       it('the repl query saves with the result id', () => {
-        expect(replSuccess.query.save).toHaveBeenCalledWith({ result_id: 11 });
+        expect(replQuery.save).toHaveBeenCalled();
       });
 
       it('the repl query becomes the controllers query', () => {
-        expect(replSuccess.query).toBe(AlertShowController.query);
+        expect(replQuery).toBe(AlertShowController.query);
       });
 
       it('calls alert.save', () => {

--- a/spec/javascripts/angular_controllers/query/query_index_controller_spec.js.es6
+++ b/spec/javascripts/angular_controllers/query/query_index_controller_spec.js.es6
@@ -173,10 +173,6 @@ describe('QueryIndexController', () => {
         digest();
       });
 
-      it('the repl query saves with the result id', () => {
-        expect(replSuccess.query.save).toHaveBeenCalledWith({ result_id: 11 });
-      });
-
       it('calls displayHandlers.navigateToLatestVersion', () => {
         expect(QueryHandler.navigateToLatestVersion).toHaveBeenCalled();
       });

--- a/spec/javascripts/angular_services/lib/open_repl_service_spec.js.es6
+++ b/spec/javascripts/angular_services/lib/open_repl_service_spec.js.es6
@@ -2,125 +2,36 @@
 
 describe('Open Repl Service', () => {
   let modal;
-  let q;
   let OpenReplService;
-  let Query;
-  let query;
-  let modalOpenParams;
-  let modalResult;
   let AceCompleters;
-
-  function expectQueryCopy(copiedQueryObject, toCopyItem) {
-    expect(Query).toHaveBeenCalled();
-    expect(query.internalize).toHaveBeenCalledWith(toCopyItem);
-    expect(copiedQueryObject.item).toEqual(toCopyItem);
-    expect(copiedQueryObject.item).not.toBe(toCopyItem);
-  }
 
   beforeEach(module('aleph'));
 
-  beforeEach(module($provide => {
-    query = {
-      internalize: jasmine.createSpy('mockQuery.internalize').and.callFake(i => {
-        query.item = i;
-      }),
-      initItem: jasmine.createSpy('mockQuery.initItem')
-    };
-
-    Query = jasmine.createSpy('MockQuery').and.returnValue(query);
-    $provide.value('Query', Query);
-  }));
-
-  beforeEach(inject((_OpenReplService_, _AceCompleters_, $uibModal, $q) => {
+  beforeEach(inject((_OpenReplService_, _AceCompleters_, $uibModal) => {
     OpenReplService = _OpenReplService_;
     modal = $uibModal;
-    q = $q;
     AceCompleters = _AceCompleters_;
 
     spyOn(AceCompleters, 'ensureSchemasData');
-
-    modalResult = {
-      then: (success, failure) => {
-       modalResult.success = success;
-       modalResult.failure = failure;
-       return 'modalPromise';
-     }
-   };
-
-    spyOn(modal, 'open').and.callFake(params => {
-      modalOpenParams = params;
-      return { result: modalResult };
-    });
+    spyOn(modal, 'open').and.returnValue({ result: 'myResult' });
   }));
 
   describe('#open', () => {
-    describe('when no query object is passed in', () => {
-      beforeEach(() => {
-        OpenReplService.open();
-      });
-
-      it('calls modal.open', () => {
-        expect(modal.open).toHaveBeenCalled();
-      });
-
-      it('ensures schema data for completers', () => {
-        expect(AceCompleters.ensureSchemasData).toHaveBeenCalled();
-      });
-
-      describe('on resolve', () => {
-        beforeEach(() => {
-          modalOpenParams.resolve.query();
-        });
-
-        it('creates a new query for the resolve.query function', () => {
-          expect(Query).toHaveBeenCalled();
-          expect(query.initItem).toHaveBeenCalled();
-        });
-      });
+    let result;
+    beforeEach(() => {
+      result = OpenReplService.open();
     });
 
-    describe('when a query object is passed in', () => {
-      beforeEach(() => {
-        OpenReplService.open({query: { item: { a: 'bleh' } }});
-      });
-
-      it('calls modal.open', () => {
-        expect(modal.open).toHaveBeenCalled();
-      });
-
-      describe('on resolve', () => {
-        let resolvedQuery;
-        beforeEach(() => {
-          resolvedQuery = modalOpenParams.resolve.query();
-        });
-
-        it('copies the passed in query for the resolve.query function', () => {
-          expectQueryCopy(resolvedQuery, { a: 'bleh'});
-        });
-      });
+    it('calls modal.open', () => {
+      expect(modal.open).toHaveBeenCalled();
     });
 
-    describe('on success from the modal instance', () => {
-      let resultObject;
-      let successReturn;
+    it('ensures schema data for completers', () => {
+      expect(AceCompleters.ensureSchemasData).toHaveBeenCalled();
+    });
 
-      beforeEach(() => {
-        resultObject = {
-          query: { item: { a: 'blerg' } },
-          result: 'queryResult'
-        };
-
-        OpenReplService.open();
-        successReturn = modalResult.success(resultObject);
-      });
-
-      it('copies the result query', () => {
-        expectQueryCopy(successReturn.query, { a: 'blerg'});
-      });
-
-      it('success returns result as is', () => {
-        expect(successReturn.result).toBe('queryResult');
-      });
+    it('returns the result', () => {
+      expect(result).toEqual('myResult');
     });
   });
 });

--- a/spec/javascripts/angular_services/query/query_handler_spec.js.es6
+++ b/spec/javascripts/angular_services/query/query_handler_spec.js.es6
@@ -7,6 +7,8 @@ describe('QueryHandler', () => {
 
   beforeEach(module('alephServices'));
 
+  function toItem(i) { return { item: i } }
+
   beforeEach(inject((_QueryHandler_, _$location_, _AlertFlash_) => {
     QueryHandler = _QueryHandler_;
     $location = _$location_;
@@ -19,12 +21,12 @@ describe('QueryHandler', () => {
 
   describe('#navigateToLatestVersion', () => {
     beforeEach(() => {
-      QueryHandler.navigateToLatestVersion({
+      QueryHandler.navigateToLatestVersion(toItem({
         id: 1,
         version: {
           id: 100
         }
-      });
+      }));
     });
 
     it('navigates to query show for query id 1', () => {
@@ -44,7 +46,7 @@ describe('QueryHandler', () => {
 
   describe('#success', () => {
     beforeEach(() => {
-      QueryHandler.success('create', true, { title: 'whatevz'});
+      QueryHandler.success('create', true, toItem({ title: 'whatevz'}));
     });
 
     it('flashes a success message', () => {

--- a/vendor/assets/stylesheets/angular-spinner/treasure-overlay-spinner.css
+++ b/vendor/assets/stylesheets/angular-spinner/treasure-overlay-spinner.css
@@ -82,7 +82,7 @@
 
 .treasure-overlay-spinner {
   position: absolute;
-  z-index: 1;
+  z-index: 10000;
   top: 50%;
   left: 50%;
   margin: -15px 0 0 -15px;
@@ -118,7 +118,7 @@ treasure-overlay-spinner.treasure-overlay-spinner-active-remove {
   top: 0;
   left: 0;
   opacity: 1;
-  z-index: 1000;
+  z-index: 10001;
 }
 
 .treasure-overlay-spinner-active-remove .treasure-overlay-spinner-container,


### PR DESCRIPTION
PR for: https://github.com/lumoslabs/aleph/issues/14

"When users save from the REPL, the REPL window closes before success or fail returns from the server.

If the save is successful, then there isn't a real issue. However, if the save fails, the query body is lost :("