### PR TITLE
use shift-enter for run query keybinding

### DIFF
--- a/app/assets/javascripts/angular/aleph.js.es6
+++ b/app/assets/javascripts/angular/aleph.js.es6
@@ -27,9 +27,9 @@
     }])
 
     .value('KeyBindings', {
-      saveQuery: new KeyBinding('Save Query', {mac: 'command+shift+s', win:'ctrl+shift+s'}),
-      runQuery: new KeyBinding('Run Query', {mac: 'command+shift+k', win:'ctrl+shift+k'}),
-      detectParameters: new KeyBinding('Detect Parameters', {mac: 'command+shift+p', win:'ctrl+shift+p'})
+      saveQuery: new KeyBinding('Save Query', { mac: 'command+shift+s', win: 'ctrl+shift+s' }),
+      runQuery: new KeyBinding('Run Query', { mac: 'shift+enter', win: 'shift+enter' }),
+      detectParameters: new KeyBinding('Detect Parameters', { mac: 'command+shift+p', win: 'ctrl+shift+p' })
     })
 
     .config(['$locationProvider', $locationProvider => {


### PR DESCRIPTION
PR for https://github.com/lumoslabs/aleph/issues/16

"Many notebook tools like Databricks, Zeppelin and Jupyter utilize the keyboard shortcut of shift+enter to execute the contents of a cell. It would be nice if Aleph would also support this shortcut."