### PR TITLE
use references instead of joins

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -18,7 +18,7 @@ class Alert < ActiveRecord::Base
   delegate :latest_query_version, to: :query
   delegate :user, to: :latest_query_version
 
-  scope :with_role, ->(role) { joins(:query).includes(:query_roles).where(query_roles: { role: role }) }
+  scope :with_role, ->(role) { references(:query).includes(:query_roles).where(query_roles: { role: role }) }
 
   LOCATIONS_FOR_ATTRIBUTES = {
     title:       { association: :query, column: :title, type: :text },

--- a/app/models/query_version.rb
+++ b/app/models/query_version.rb
@@ -14,7 +14,7 @@ class QueryVersion < ActiveRecord::Base
     before_create :github_save
   end
 
-  scope :with_role, ->(role) { joins(:query).includes(:query_roles).where(query_roles: { role: role }) }
+  scope :with_role, ->(role) { references(:query).includes(:query_roles).where(query_roles: { role: role }) }
 
   delegate :to_csv, to: :latest_completed_result
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -10,7 +10,7 @@ class Result < ActiveRecord::Base
   serialize :headers, JSON
 
   scope :completed, -> { where(status: 'complete') }
-  scope :with_role, ->(role) { joins(:query).includes(:query_roles).where(query_roles: { role: role }) }
+  scope :with_role, ->(role) { references(:query).includes(:query_roles).where(query_roles: { role: role }) }
 
   delegate :ongoing_row_count, to: :redis_result_row_count
 

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -3,5 +3,5 @@ class Visualization < ActiveRecord::Base
   has_one :query, through: :query_version
   has_many :query_roles, through: :query
 
-  scope :with_role, ->(role) { joins(:query).includes(:query_roles).where(query_roles: { role: role }) }
+  scope :with_role, ->(role) { references(:query).includes(:query_roles).where(query_roles: { role: role }) }
 end


### PR DESCRIPTION
PR for 

https://github.com/lumoslabs/aleph/issues/13
https://github.com/lumoslabs/aleph/issues/15

In general, we want our models to work well with the PaginatedSearch module. This means that the base relation we pass to pagination will go through a lot of AREL manipulation, specifcally using `references` and `includes`.

Apparently, `joins` does not work so well.

Also, just to note, since it is not so obvious. The `with_role` scope is used by CanCan and this scope/relation is what is ultimately used in the controllers as the base relation for pagination. This is all done in the file `ability.rb`