### PR TITLE
Get rid of quotes if they are problematic

### DIFF
--- a/lib/pagination_search/hash_paginate.rb
+++ b/lib/pagination_search/hash_paginate.rb
@@ -29,8 +29,9 @@ module PaginationSearch
     end
 
     def searched(items, search)
-      if search.present?
-        search_conditions = PaginationSearch::SearchConditions.process(search)
+      search_conditions = PaginationSearch::SearchConditions.process(search) if search.present?
+
+      if search_conditions
         items.select { |i| accept?(i, search_conditions) }
       else
         items

--- a/lib/pagination_search/search_conditions.rb
+++ b/lib/pagination_search/search_conditions.rb
@@ -27,7 +27,7 @@ module PaginationSearch
 
     class << self
       def process(search_string)
-        wrapped attribute_cleaned grouped separated search_string
+        wrapped attribute_cleaned grouped separated quotation_safe search_string
       end
 
       private
@@ -37,10 +37,18 @@ module PaginationSearch
         Result.new(cleaned_grouped_hash)
       end
 
+      def quotation_safe(search_string)
+        if search_string.count('""').odd? || /\S\"\S/.match(search_string)
+          search_string.tr('""', ' ')
+        else
+          search_string
+        end
+      end
+
       def separated(search_string)
         CSV::parse_line(search_string, col_sep: ' ').compact
       rescue CSV::MalformedCSVError => mce
-        CSV::parse_line(search_string.tr('"', ' '), col_sep: ' ').compact
+        nil
       end
 
       def grouped(terms)

--- a/lib/pagination_search/search_conditions.rb
+++ b/lib/pagination_search/search_conditions.rb
@@ -27,7 +27,7 @@ module PaginationSearch
 
     class << self
       def process(search_string)
-        wrapped attribute_cleaned grouped separated quotation_safe search_string
+        wrapped attribute_cleaned grouped separated search_string
       end
 
       private
@@ -35,14 +35,6 @@ module PaginationSearch
       def wrapped(cleaned_grouped_hash)
         return nil if cleaned_grouped_hash.nil?
         Result.new(cleaned_grouped_hash)
-      end
-
-      def quotation_safe(search_string)
-        if search_string.count('""').odd? || /\S\"\S/.match(search_string)
-          search_string.tr('""', ' ')
-        else
-          search_string
-        end
       end
 
       def separated(search_string)

--- a/lib/pagination_search/search_conditions.rb
+++ b/lib/pagination_search/search_conditions.rb
@@ -38,9 +38,9 @@ module PaginationSearch
       end
 
       def separated(search_string)
-        CSV::parse_line(search_string, col_sep: ' ')
+        CSV::parse_line(search_string, col_sep: ' ').compact
       rescue CSV::MalformedCSVError => mce
-        nil
+        CSV::parse_line(search_string.tr('"', ' '), col_sep: ' ').compact
       end
 
       def grouped(terms)

--- a/spec/lib/pagination_search/hash_paginate_spec.rb
+++ b/spec/lib/pagination_search/hash_paginate_spec.rb
@@ -17,7 +17,7 @@ describe PaginationSearch::HashPaginate do
   describe '#page' do
 
     context 'with no search terms' do
-      
+
       context 'when items is nil' do
         it 'returns empty array' do
           expect(subject.page(nil, first_page)).to eq([])
@@ -71,6 +71,15 @@ describe PaginationSearch::HashPaginate do
 
         expect(subject.page(items, second_page.merge(sort_by: 'id', sort_descending: 'true'))).to eq([
           { 'id' => 1, 'x' => 'square', 'y' => 'hippo' }
+        ])
+      end
+    end
+
+    context  'when search terms are not correctly formated' do
+      it 'returns all items' do
+        expect(subject.page(items, first_page.merge(search: '"triangle'))).to eq([
+          {"id"=>1, "x"=>"square", "y"=>"hippo"}, 
+          {"id"=>2, "x"=>"circle", "y"=>"triangle_monkey"}
         ])
       end
     end

--- a/spec/lib/pagination_search/search_conditions_spec.rb
+++ b/spec/lib/pagination_search/search_conditions_spec.rb
@@ -11,11 +11,11 @@ module PaginationSearch
         expect(subject.class).to eq(SearchConditions::Result)
       end
 
-      context 'when term string contains incorrect quotation marks' do
-        let(:term_string) { '"this is an"unfinished" string ' }
+      context 'when term string contains an invalid string' do
+        let(:term_string) { '"this is an unfinished string' }
 
-        it 'removes the quotes' do
-          expect(subject.trait_term_hash).to eq({"" => ['this', 'is', 'an', 'unfinished', 'string']})
+        it 'returns nil' do
+          expect(subject).to be_nil
         end
       end
 

--- a/spec/lib/pagination_search/search_conditions_spec.rb
+++ b/spec/lib/pagination_search/search_conditions_spec.rb
@@ -11,11 +11,11 @@ module PaginationSearch
         expect(subject.class).to eq(SearchConditions::Result)
       end
 
-      context 'when term string contains an invalid string' do
-        let(:term_string) { '"this is an unfinished string' }
+      context 'when term string contains incorrect quotation marks' do
+        let(:term_string) { '"this is an"unfinished" string ' }
 
-        it 'returns nil' do
-          expect(subject).to be_nil
+        it 'removes the quotes' do
+          expect(subject.trait_term_hash).to eq({"" => ['this', 'is', 'an', 'unfinished', 'string']})
         end
       end
 


### PR DESCRIPTION
This aims to solving this issue https://github.com/lumoslabs/aleph/issues/24.
It also compacts the results of `separated`, as there was the possibility of getting an error later when the resulting array contained `nil` elements (for example, if the search query ended with an extra space).