### PR TITLE
for the schema query, retry more and retry longer with linear decay

### DIFF
--- a/config/initializers/pester.rb
+++ b/config/initializers/pester.rb
@@ -2,8 +2,9 @@ Pester.configure do |c|
   c.logger = Rails.logger
 
   c.environments[:schema_refresh] = {
-    delay_interval:      0,
-    on_retry:            Pester::Behaviors::Sleep::Constant
+    delay_interval:      1,
+    max_attempts:        12,
+    on_retry:            Pester::Behaviors::Sleep::Linear
   }
 
   c.environments[:s3] = {


### PR DESCRIPTION
currently the retry just does 4 query attempts quickly with no delay. unfortunately, this often means the attempts are exhausted before the query succeeds which leads to stale schema information.

we probably want some modest amount of delay. and more attempts.