### PR TITLE
allow semicolon at end of query

### DIFF
--- a/app/models/query_execution.rb
+++ b/app/models/query_execution.rb
@@ -69,6 +69,7 @@ EOF
     # then read in the first 100 rows from the file as sample rows
     # Note: snowflake unload currently has a max file size of 5 GB.
     connection.reconnect_on_failure do
+      body = body.strip.gsub(/;$/, '')
       location = File.join(connection.unload_target, result.current_result_filename)
       sql = SNOWFLAKE_UNLOAD_SQL % {location: location, query: body, max_file_size: connection.max_file_size}
       row = connection.connection.fetch(sql).first


### PR DESCRIPTION
https://lumoslabs.atlassian.net/browse/CORE-687

Snowflake odbc driver return errors when query ends with a semicolon; strip it from the query text before execution.