### PR TITLE
0.4.0 bug fixes

### DIFF
--- a/app/models/query_execution.rb
+++ b/app/models/query_execution.rb
@@ -69,6 +69,7 @@ EOF
     # then read in the first 100 rows from the file as sample rows
     # Note: snowflake unload currently has a max file size of 5 GB.
     connection.reconnect_on_failure do
+      body = body.strip.gsub(/;$/, '')
       location = File.join(connection.unload_target, result.current_result_filename)
       sql = SNOWFLAKE_UNLOAD_SQL % {location: location, query: body, max_file_size: connection.max_file_size}
       row = connection.connection.fetch(sql).first

--- a/lib/redshift_pg/connection.rb
+++ b/lib/redshift_pg/connection.rb
@@ -20,7 +20,7 @@ module RedshiftPG
         return yield
       rescue PG::UnableToSend, PG::ConnectionBad
         pg_connection.reset
-        retry
+        return yield   # retry once
       end
     end
 

--- a/lib/snowflake_db/connection.rb
+++ b/lib/snowflake_db/connection.rb
@@ -20,7 +20,7 @@ module SnowflakeDB
       rescue Sequel::DatabaseError => e
         raise unless connection_expired_error?(e)
         connection.reset
-        retry
+        return yield   # retry once
       end
     end
 


### PR DESCRIPTION
https://lumoslabs.atlassian.net/browse/CORE-687

* Snowflake odbc driver return errors when query ends with a semicolon; strip it from the query text before execution.
* retry bad connection exactly once rather than infinitely 
