### PR TITLE
#91 fix error when snowflake returns empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file using [Semantic Versioning](http://semver.org/).
 
+## [0.4.2] - 2019-09-25
+### Fixed
+- [Error when Snowflake query returns empty result set](https://github.com/lumoslabs/aleph/issues/91)
+
 ## [0.4.1] - 2019-09-10
 ### Fixed
 - [Bug fixes for v0.4.0](https://github.com/lumoslabs/aleph/pull/89) 
@@ -23,7 +27,7 @@ All notable changes to this project will be documented in this file using [Seman
 - [Site wide, saved filter for schema](https://github.com/lumoslabs/aleph/issues/38)
 
 ### Fixed
-- [Use trusty for travis](https://github.com/lumoslabs/aleph/issues/67)
+- [Use trusty for travis](https://github.com/lumoslabs/al eph/issues/67)
 - [Display 24-hour format](https://github.com/lumoslabs/aleph/issues/53)
 - [Schema search should be able to handle numbers](https://github.com/lumoslabs/aleph/issues/59)
 - [Clean up /tmp result files when query fails](https://github.com/lumoslabs/aleph/issues/37)
@@ -31,8 +35,7 @@ All notable changes to this project will be documented in this file using [Seman
 
 ## [0.1.0] - 2017-04-27
 ### Features
-- [Auto-complete on dot](https://github.com/lumoslabs/aleph/issues/48)
-
+- [Auto-complete on dot](https://github.com/lumoslabs/aleph/issues/48)auser
 ### Fixed
 - [change retry configuration for schema query](https://github.com/lumoslabs/aleph/issues/46)
 

--- a/aleph.gemspec
+++ b/aleph.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = 'aleph_analytics'
-  s.version     = '0.4.1'
-  s.date        = '2019-09-10'
+  s.version     = '0.4.2'
+  s.date        = '2019-09-25'
   s.summary     = 'Redshift/Snowflake analytics platform'
   s.description = 'The best way to develop and share queries/investigations/results within an analytics team'
-  s.authors     = ['Andrew Xue', 'Rob Froetscher']
-  s.email       = 'andrew@lumoslabs.com'
+  s.authors     = ['Andrew Xue', 'Rob Froetscher', 'Joyce Lau']
+  s.email       = 'eng-data@lumoslabs.com'
   s.files       = Dir.glob('{app,bin,lib,config,vendor}/**/*') +
                   # need to find the hidden sprockets manifest in public/assets
                   Dir.glob('public/assets/**/*', File::FNM_DOTMATCH) +

--- a/lib/result_csv_generator.rb
+++ b/lib/result_csv_generator.rb
@@ -3,10 +3,15 @@ require 'csv'
 class ResultCsvGenerator
   attr_accessor :csv
 
-  def initialize(result_id, headers)
+  def initialize(result_id, headers, create_empty = false)
     @result_id = result_id
     @headers = headers
     @csv_service = CsvService.new(@result_id)
+
+    if create_empty
+      setup_csv.call()
+      finish_csv.call(0)
+    end
   end
 
   def callbacks


### PR DESCRIPTION
Aleph returns an error whenever a Snowflake query returns no row.
```
The specified key does not exist.
```

Aleph currently executes a unload of the query and read the first 100 rows from the unloaded files in s3.  Since Snowflake does not create a file when result file is empty, Aleph generates the error when it tries to read from the file.

Check number of rows unloaded.  If zero, create an "empty" file (file header row only) from aleph.
