### PR TITLE
Update schema query

### DIFF
--- a/lib/schemas/descriptor.rb
+++ b/lib/schemas/descriptor.rb
@@ -10,7 +10,7 @@ module Schemas
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(table_schema) AS ': ''}table_schema,
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(table_name) AS ': ''}table_name,
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(column_name) AS ': ''}column_name,
-        COALESCE(udt_name, data_type),
+        COALESCE(udt_name, data_type) AS udt_name,
         character_maximum_length
       FROM information_schema.columns
       WHERE table_schema NOT IN ('INFORMATION_SCHEMA', 'information_schema', 'pg_catalog', 'public')

--- a/lib/schemas/descriptor.rb
+++ b/lib/schemas/descriptor.rb
@@ -10,7 +10,7 @@ module Schemas
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(table_schema) AS ': ''}table_schema,
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(table_name) AS ': ''}table_name,
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(column_name) AS ': ''}column_name,
-        udt_name,
+        COALESCE(udt_name, data_type),
         character_maximum_length
       FROM information_schema.columns
       WHERE table_schema NOT IN ('INFORMATION_SCHEMA', 'information_schema', 'pg_catalog', 'public')

--- a/lib/schemas/descriptor.rb
+++ b/lib/schemas/descriptor.rb
@@ -13,7 +13,7 @@ module Schemas
         (COALESCE(udt_name, data_type) || 
           CASE 
             WHEN character_maximum_length IS NOT NULL THEN '(' || character_maximum_length || ')'
-            WHEN numeric_precision IS NOT NULL THEN '(' || numeric_precision || ')'
+            WHEN numeric_precision IS NOT NULL THEN '(' || numeric_precision || ', ' || numeric_scale || ')'
             ELSE ''
           END) AS udt_name,
         character_maximum_length

--- a/lib/schemas/descriptor.rb
+++ b/lib/schemas/descriptor.rb
@@ -10,7 +10,12 @@ module Schemas
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(table_schema) AS ': ''}table_schema,
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(table_name) AS ': ''}table_name,
         #{LOWERCASE_DB_IDENTIFIERS ? 'LOWER(column_name) AS ': ''}column_name,
-        COALESCE(udt_name, data_type) AS udt_name,
+        (COALESCE(udt_name, data_type) || 
+          CASE 
+            WHEN character_maximum_length IS NOT NULL THEN '(' || character_maximum_length || ')'
+            WHEN numeric_precision IS NOT NULL THEN '(' || numeric_precision || ')'
+            ELSE ''
+          END) AS udt_name,
         character_maximum_length
       FROM information_schema.columns
       WHERE table_schema NOT IN ('INFORMATION_SCHEMA', 'information_schema', 'pg_catalog', 'public')


### PR DESCRIPTION
[Postgres will set](https://www.postgresql.org/docs/9.3/infoschema-element-types.html) `data_type` as `USER-DEFINED`, which I'm assuming is why we went with `udt_name,` which Redshift in particular apparently was also filling with the data_type, if it wasn't actually user-defined. 

This seems to work in Snowflake, as I guess udt_name might technically be in the standard.