### PR TITLE
Move access token from query params to header

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: travis-pro
+service_name: travis-ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 
 All notable changes to this project will be documented in this file using [Semantic Versioning](http://semver.org/).
 
+## [0.4.9] - 2021-06-15
+### Fixed
+- Move Github access_token from query params to header params
+
 ## [0.4.8] - 2020-01-20
 ### Fixed
 - [Fix issue with thread refresh_schema](https://github.com/lumoslabs/aleph/issues/103)

--- a/aleph.gemspec
+++ b/aleph.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'aleph_analytics'
-  s.version     = '0.4.8'
-  s.date        = '2020-01-20'
+  s.version     = '0.4.9.pre.dev'
+  s.date        = '2021-06-15'
   s.summary     = 'Redshift/Snowflake analytics platform'
   s.description = 'The best way to develop and share queries/investigations/results within an analytics team'
   s.authors     = ['Andrew Xue', 'Rob Froetscher', 'Joyce Lau']

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -4,11 +4,6 @@ module Github
   APP_NAME        = APP_CONFIG['github_app_name']
   OWNER           = APP_CONFIG['github_owner']
   REPO            = APP_CONFIG['github_repo']
-  REQUEST_PARAMS = {
-    'access_token' => ENV['GITHUB_APPLICATION_ACCESS_TOKEN'],
-    'client_id' => ENV['GITHUB_APPLICATION_CLIENT_ID'],
-    'client_secret' => ENV['GITHUB_APPLICATION_CLIENT_SECRET']
-  }
   VALID_VERBS = {
     get: Net::HTTP::Get,
     post: Net::HTTP::Post,
@@ -25,7 +20,7 @@ module Github
 
   def self.send_request(verb, url, params={})
     raise "invalid HTTP verb #{verb}" unless VALID_VERBS.include?(verb)
-    query_params = REQUEST_PARAMS
+    query_params = ''
     query_params.merge!(params) if verb == :get
     url += "?#{query_params.to_query}"
 
@@ -36,6 +31,7 @@ module Github
 
     request = VALID_VERBS[verb].new(uri.request_uri)
     request['Accept'] = 'application/vnd.github.v3+json'
+    request['Authorization: token '] = ENV['GITHUB_APPLICATION_ACCESS_TOKEN']
     request['User-Agent'] = APP_NAME
 
     if request.request_body_permitted?


### PR DESCRIPTION
https://lumoslabs.atlassian.net/browse/DATAENG-326

This change is introduced because of the deprecation of API usage as we used it before. Refer to this documentation for further information: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

We needed to move access_token from query params to header params.